### PR TITLE
Add fix for patch methods silent crash

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -223,30 +223,43 @@ var generateSubResource = module.exports.generateSubResource = function(ramlReso
  * @returns {Object} deconflicted ramlResource;
  */
 var deconflictRamlResource = module.exports.deconflictRamlResource = function(ramlResource){
+  // Grab parent resource methods that can have conflicts
+  var potentialConflictVerbs = ['put', 'patch'];
+  var parentResourceMethods = _.filter(ramlResource.methods, function(method){
+    return _.contains(potentialConflictVerbs, method.method);
+  });
+  // pluck the methods names from the resources
+  var parentResourceMethodNames = _.pluck(parentResourceMethods, 'method');
+
+  // For each resource in the ramlfile
   _.forEach(ramlResource.resources, function(resource){
     // If resource is IdParam
     if(generatorUtil.startsWithIdParam(resource.displayName)){
       // Deduplicate (remove) put and patch methods in root resource
-      var resourceMethods = _.filter(ramlResource.methods, function(method){
-        return _.contains(['put', 'patch'], method.method);
-      });
-      var resourceMethodNames = _.pluck(resourceMethods, 'method');
-      var conflictedMethods = _.remove(ramlResource.methods, function(method){
-        return _.contains(resourceMethodNames, method.method);
-      });
-      // For each conflictedMethod
-      _.forEach(conflictedMethods, function(conflictedMethod){
-        // Append their description to the id resource method description
-        var resourceMethod = _.find(resource.methods, function(resourceMethod){
-                          return resourceMethod.method === conflictedMethod.method;
-                        });
-        resourceMethod.description = conflictedMethod.description + '\nor ' + resourceMethod.description;
-      });
+      // Pluck the methods names from the resources
+      var resourceMethodNames = _.pluck(resource.methods, 'method');
+      var conflictedMethods = [];
+      // if overlap between resource and parentResource
+      if (_.intersection([resourceMethodNames, parentResourceMethodNames])) {
+        // Remove conflicted methods from parent resource
+        conflictedParentMethods  = _.remove(ramlResource.methods, function(method){
+          return _.contains(resourceMethodNames, method.method);
+        });
+        // For each conflictedMethod
+        _.forEach(conflictedParentMethods, function(conflictedParentMethod){
+          // Append their description to the id resource method description
+          var resourceMethod = _.find(resource.methods, function(resourceMethod){
+            return resourceMethod.method === conflictedParentMethod.method;
+          });
+          if (resourceMethod) {
+            resourceMethod.description = conflictedParentMethod.description + '\nor ' + resourceMethod.description;
+          }
+        });
+      }
     }
   });
   return ramlResource;
 };
-
 /**
  * A recursive helper method for generating resources.
  *


### PR DESCRIPTION
Cause by accessing a property of undefined on undefined.

Logic was broken before where it would detect a conflict whenever a PUT or PATCH method was used regardless if the collection resource had a PUT or a PATCH method. This caused a JavaScript error that got swallowed by the yeoman generator.

If you could merge this in it'd get the Scott and Jeanette unstuck. I had to revert the change that allows PATCH methods and these deduplicating collection and item resource PUT and PATCH methods.
